### PR TITLE
Perform revisions to appease Docusaurus

### DIFF
--- a/website/docs/1-identify-stakeholders.md
+++ b/website/docs/1-identify-stakeholders.md
@@ -13,9 +13,9 @@ This team member reviews and approves the work of the other stakeholders and is 
 The model owner understands the use case and makes the final decision about the model's usage.
 This role aligns with the NIST AI RMF Playbook guidelines in Measure [2.8](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Measure#Measure%202.8).
 
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ## 1.2 Identify stakeholders
 **Model owner**: Identify relevant stakeholders.
@@ -23,34 +23,34 @@ This role aligns with the NIST AI RMF Playbook guidelines in Measure [2.8](https
 Identify the **model developer(s)** and provide their contact information.
 The model developer is the data scientist who develops the model.
 
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 Identify the **model engineer(s)** and provide their contact information.
 The model engineer is responsible for deploying the model.
 
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 Identify the **model risk owner(s)** and provide their contact information.
 The model risk owner identifies, manages, and documents model risks.
 
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 Identify the **data engineer(s)** and provide their contact information.
 The data engineer compiles and prepares the data for modeling.
 
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 Identify the **domain expert(s)** and provide their contact information.
 The domain expert is available to address business and domain questions.
 
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>

--- a/website/docs/2-document-project.md
+++ b/website/docs/2-document-project.md
@@ -16,79 +16,79 @@ The following documentation helps define the project in a centralized location.
 * [ ] Depreciated or archived
 
 If applicable, add any additional details: 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.1.2 Document purpose and usage
 **Model owner**: Document the purpose of the modeling project, including model usage, scope, assumptions, limitations, and potential benefits and harms in accordance with the *NIST AI RMF Playbook* guidelines in Map [1.1](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%201.1), [3.2](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%203.2), and [3.3](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%203.3).
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.1.3 Document end users
 **Model owner**: Document end users and their expected usage in accordance with the *NIST AI RMF Playbook* guidelines in Map [1.1](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%201.1).
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.1.4 Document baseline metrics
 **Model owner**: Document the baseline metrics or processes used to measure the success of the current decisioning system.
 A decisioning system can be a model, a database, or a process of communication and knowledge sharing.
 Consult the *NIST AI RMF Playbook* guidelines in Map [3.1](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%203.1).
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.1.5 Document feedback strategy
 **Model owner**: Document the feedback strategy.
 The strategy should outline how users of the AI system will provide feedback to developers and deployers of the AI system in accordance to the *NIST AI RMF Playbook* guidelines in Map [5.2](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%205.2).
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.1.6 Document performance metrics
 **Model owner**: Document preferred performance metrics, including fit statistics.
 Fit statistics are statistical values that assess how well a model fits a set of data.
 Metrics are used to evaluate model performance.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.1.7 Approve documentation?
 **Model owner**: Review and confirm your documentation.
@@ -98,17 +98,17 @@ Did you provide all necessary documentation?
 * [ ] Yes
 * [ ] No
 
-If the answer is no, please list what is missing and re-assign [step 2.1](#2.1-Model-owner-prepares-documentation) to yourself for completion.
+If the answer is no, please list what is missing and re-assign [step 2.1](#21-model-owner-prepares-documentation) to yourself for completion.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+<br></br>
 
 ## 2.2 Model risk owner prepares documentation
 
@@ -117,14 +117,14 @@ If the answer is no, please list what is missing and re-assign [step 2.1](#2.1-M
 Negative impacts include potential reduction in the well-being or financial security of individuals, communities, organizations, society, and the planet.
 Legal risks might include risks of infringement for a third party's intellectual property or other rights.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.2.2 Document organizational risk tolerance
 **Model risk owner**: Document the organization's risk tolerance and criteria for action in accordance with the *NIST AI RMF Playbook* guidelines in Map [3.2](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%203.2).
@@ -132,14 +132,14 @@ Risk tolerance defines how acceptable various types of risk are according to the
 Risk types include financial risk, reputational risk, and potential harm to individuals present within the data or subject to the AI system.
 Criteria for action describe thresholds or events that would lead to an organization taking risk management measures, including changes to the model or the decision to deploy the model.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.2.3 Approve documentation?
 **Model owner**: Review documentation supplied by the model risk owner.
@@ -149,17 +149,17 @@ Did the model risk owner provide all necessary documentation?
 * [ ] Yes
 * [ ] No
 
-If the answer is no, please list what is missing and re-assign [step 2.2](#2.2-Model-risk-owner-prepares-documentation) to the model risk owner for completion.
+If the answer is no, please list what is missing and re-assign [step 2.2](#22-model-risk-owner-prepares-documentation) to the model risk owner for completion.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+<br></br>
 
 ## 2.3 Model engineer prepares documentation
 
@@ -167,26 +167,26 @@ If the answer is no, please list what is missing and re-assign [step 2.2](#2.2-M
 **Model engineer**: Document data processes throughout the AI life cycle.
 This could include how data is prepared to be passed to the AI system, how data is passed to the system, and how the output is returned and used by other systems in accordance with the *NIST AI RMF Playbook* guidelines in Map [1.1](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%201.1) and [1.2](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%201.2).
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.3.2 Document the deployment location
 **Model engineer**: Document the deployment location and external connections.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.3.3 Approve documentation?
 **Model owner**: Review documentation supplied by the model engineer.
@@ -196,68 +196,68 @@ Did the model engineer provide all necessary documentation?
 * [ ] Yes
 * [ ] No
 
-If the answer is no, please list what is missing and re-assign [step 2.3](#2.3-Model-engineer-prepares-documentation) to the model engineer for completion.
+If the answer is no, please list what is missing and re-assign [step 2.3](#23-model-engineer-prepares-documentation) to the model engineer for completion.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+<br></br>
 
 ## 2.4 Data engineer prepares documentation
 
 ### 2.4.1 Document bias assessment variables
 **Data engineer**: Document variables that will be used to identify or assess bias in the data or models.
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.4.2 Document the time period covered
 **Data engineer**: Document the time period covered for both the collection and creation of the data.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.4.3 Document data limitations
 **Data engineer**: Document any known limitations of the data, including issues arising during data collection, selection, labeling, cleaning, and analysis, in accordance with the *NIST AI RMF Playbook* guidelines in Map
 [2.3](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Map#Map%202.3).
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.4.4 Document private variables
 **Data engineer**: Document variables that might be considered private according to organizational guidelines and applicable regulations.
 Consider whether the unintended use of private data might expose people to harm or legal action and document a mitigation strategy in accordance with the *NIST AI RMF Playbook* guidelines in Measure [2.10](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Measure#Measure%202.10).
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.4.5 Approve documentation?
 **Model owner**: Review documentation supplied by the data engineer.
@@ -267,17 +267,17 @@ Did the data engineer provide all necessary documentation?
 * [ ] Yes
 * [ ] No
 
-If the answer is no, please list what is missing and re-assign [step 2.4](#2.4-Data-engineer-prepares-documentation) to the data engineer for completion.
+If the answer is no, please list what is missing and re-assign [step 2.4](#24-data-engineer-prepares-documentation) to the data engineer for completion.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+<br></br>
 
 
 ## 2.5 Model developer or data engineer prepares documentation
@@ -286,14 +286,14 @@ If the answer is no, please list what is missing and re-assign [step 2.4](#2.4-D
 **Model developer or data engineer**: Document model and project metadata, including the name of the model owner, timestamps, statistical analysis tools and the version used, model performance at training time, and any other relevant information.
 This information is automatically compiled for models developed in Model Studio but can be compiled via sasctl packages for Python or R models or macros for SAS code models.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.5.2 Document testing strategy
 **Model developer or data engineer**: Document the model testing strategy in
@@ -308,29 +308,29 @@ Rather, the questions can guide the development of the strategy itself, which sh
 3. How does the model behave when encountering values not included in the training data? 
 4. Are training and testing samples independent? What method was used to create the training and testing data sets?
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.5.3 Document thresholds
 **Model developer or data engineer**: Document threshold values for the preferred model performance metric.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.5.4 Document protected classes
 **Model developer or data engineer**: Document relevant protected classes and their expected proportions among individuals impacted by the AI system in accordance with the *NIST AI RMF Playbook* guidelines in Map
@@ -339,14 +339,14 @@ Protected classes are groups of people who are legally protected from discrimina
 Classes can include age, ancestry, disability, ethnicity, gender, gender identity or expression, genetic information, HIV/AIDS status, military status, national origin, pregnancy, race, religion, sex, sexual orientation, and veteran status.
 Legally defined protected classes can vary by country or region.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 2.5.5 Approve documentation?
 **Model owner**: Review documentation that was supplied by the model developer or data engineer.
@@ -356,14 +356,14 @@ Did the model developer or data engineer provide all necessary documentation?
 * [ ] Yes
 * [ ] No
 
-If the answer is no, please list what is missing and re-assign [step 2.5](#2.5-Model-developer-or-data-engineer-prepares-documentation) to the model developer and/or data engineer for completion.
+If the answer is no, please list what is missing and re-assign [step 2.5](#25-model-developer-or-data-engineer-prepares-documentation) to the model developer and/or data engineer for completion.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+<br></br>

--- a/website/docs/3-prepare-and-assess-data.md
+++ b/website/docs/3-prepare-and-assess-data.md
@@ -13,14 +13,14 @@ Prepare and assess data for future model training.
 
 If applicable, add any additional details:
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
 
 ## 3.2 Individuals affected?
 **Model owner**: Indicate whether individuals are represented in the data or affected by the use case.
@@ -28,19 +28,19 @@ If applicable, add any additional details:
 Are individuals represented in the data or affected by the use case?
 
 * [ ] Yes. If selected, continue to next step. 
-* [ ] No. If selected, move to [step 3.5](#3.5-Approve-data). 
+* [ ] No. If selected, move to [step 3.5](#35-approve-data). 
 
 If yes, please provide additional information.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+<br></br>
 
 
 ## 3.3 Assess data privacy
@@ -52,62 +52,62 @@ PII is any information connected to a specific individual that could be used to 
 Does the data contain Personally Identifiable Information (PII)?
 
 * [ ] Yes. If selected, continue to next step. 
-* [ ] No. If selected, move to [step 3.3.5](#3.3.5-Data-privacy-risk-approval).
+* [ ] No. If selected, move to [step 3.3.5](#335-data-privacy-risk-approval).
 
 If yes, please provide additional information. 
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 3.3.2 PII required?
 **Model developer**: Is the PII required due to the model use case or performance?
 
 Does this use case require that Personally Identifiable Information (PII) be included in the data?
 
-* [ ] Yes. If yes, move to [step 3.3.4](#3.3.4-Document-variables-and-risks).
+* [ ] Yes. If yes, move to [step 3.3.4](#334-document-variables-and-risks).
 * [ ] No. If no, continue to next step. 
 
 If applicable, please provide additional information. 
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 3.3.3  Remove or mask PII
 **Data engineer**: If the PII is not required for the use case, remove PII, or mask (anonymize) to protect the privacy of individuals within the data.
 Describe the steps taken to remove PII or mask the data.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 3.3.4 Document variables and risks
 **Model developer or data engineer**: Document variables of concern or those that introduce privacy risks, and describe the risks of their inclusion in accordance with the *NIST AI RMF Playbook* guidelines in Measure [2.7](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook/Measure#Measure%202.7).
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 3.3.5 Data privacy risk approval
 **Model owner**: Do you approve the assessment and documentation of privacy risks?
@@ -117,11 +117,11 @@ Describe the steps taken to remove PII or mask the data.
 
 If no, please justify your response and reassign step 3 for completion.
 
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+<br></br>
 
 ## 3.4 Assess data bias
 
@@ -129,14 +129,14 @@ If no, please justify your response and reassign step 3 for completion.
 **Model developer or data engineer**: Document potential biases introduced due to data quality.
 Consider how data quality issues can result in unwanted biases. For example, do patterns in missing or incomplete data correspond to any protected group classes, like individuals of a specific demographic group?If so, document this bias.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 3.4.2 Protected classes or proxy variables?
 **Model developer or data engineer**: Indicate whether the data includes information relating to protected classes or proxy variables for protected classes.
@@ -146,7 +146,7 @@ Proxy variables are not themselves protected classes but are statistically relat
 Does the data include information relating to protected classes or proxy variables for protected classes?
 
 * [ ] Yes. If selected, continue to the next step. 
-* [ ] No. If selected, move to [step 3.4.7](#3.4.7-Data-representative-of-population). 
+* [ ] No. If selected, move to [step 3.4.7](#347-data-representative-of-population). 
 
 ### 3.4.3 Are variables inputs to model?
 **Model developer**: Indicate whether the model variable includes information about protected classes or proxy variables for protected classes. If so, document the protected class or proxy variables that are to be included in the model.
@@ -157,35 +157,35 @@ Proxy variables are not themselves protected classes but are statistically relat
 Does the model variables include information relating to protected classes or proxy variables for protected classes?
 
 * [ ] Yes. If selected, continue to the next step. 
-* [ ] No. If selected, move to [step 3.4.7](#3.4.7-Data-representative-of-population).  
+* [ ] No. If selected, move to [step 3.4.7](#347-data-representative-of-population).  
 
 ### 3.4.4 Protected classes or proxy variables required?
 **Model developer**: Are protected classes or proxy variables included in the model required, given the use case or model performance?
 
 * [ ] Yes. If selected, document why these variables are required and continue to next step.
-* [ ] No. If selected, move to [step 3.4.6](#3.4.6-Remove-variables-from-model). 
+* [ ] No. If selected, move to [step 3.4.6](#346-remove-variables-from-model). 
 
 If applicable, add any additional details:
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 3.4.5 Document risks and justification
 **Model developer**: Document data bias risks and associated variables and provide justification for their inclusion.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 3.4.6 Remove variables from model
 **Model developer**: If there are unnecessary protected classes or proxy variables in the model, remove them from the model.
@@ -194,14 +194,14 @@ If applicable, add any additional details:
 * [ ]  Not Completed
 
 If applicable, add any additional details:
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 3.4.7 Data representative of population
 **Model developer or data engineer**: Indicate whether the data represents the population to which the model will be applied.
@@ -209,25 +209,25 @@ Representativeness indicates whether the individuals present in the data mirror 
 
 Does the data represent the population to which the model will be applied?
 
-* [ ] Yes. If selected, provide evidence below the data is representative and move to [step 3.4.13](#3.4.13-Data-bias-approval). 
+* [ ] Yes. If selected, provide evidence below the data is representative and move to [step 3.4.13](#3413-data-bias-approval). 
 * [ ] No. If selected, contine to next step. 
 
 If applicable, add any additional details:
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 3.4.8 Representative data available?
 **Model developer or data engineer**: If there is evidence that the data used to train the model is not representative, indicate whether representative data is available.
 
 Is representative data available?
 
-* [ ] Yes. If selected, move to [step 3.4.12](#3.4.12-Use-representative-data). 
+* [ ] Yes. If selected, move to [step 3.4.12](#3412-use-representative-data). 
 * [ ] No. If selected, continue to next step. 
 
 ### 3.4.9 Alternative strategies exist?
@@ -236,41 +236,41 @@ If so, document those strategies and implement them.
 
 Do alternative strategies exist?
 
-* [ ] Yes. If selected, move to [step 3.4.12](#3.4.12-Use-representative-data). 
+* [ ] Yes. If selected, move to [step 3.4.12](#3412-use-representative-data). 
 * [ ] No. If selected, contine to next step. 
 
 
 ### 3.4.10 Document data bias risks and implications
 **Model developer or data engineer**: Document data bias risks and any implications that could arise as a result. Consider risks that might arise from availability bias, recall bias, exclusion bias, pre-processing bias, measurement bias, time-interval bias, historical bias, selection bias, attrition bias, or other forms of bias.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 What should be done about the nonexistent alternative strategies?
 
 * [ ] End the workflow. If selected, please depreciate the project abd update [step 2.1.1](2-document-project.md).
-* [ ] Modify or update data. If selected, return to [step 3.1](#3.1-Collect-and-prepare-analytical-base-table).
+* [ ] Modify or update data. If selected, return to [step 3.1](#31-collect-and-prepare-analytical-base-table).
 * [ ] Move forward with the data.If selected, contine to next step. 
 
 ### 3.4.11 Justify moving forward
 **Model owner**: If you have decided to move forward with using the data even though issues were identified, provide justification for moving forward with the data. 
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
-Move to [step 3.4.13](#3.4.13-Data-bias-approval).
+Move to [step 3.4.13](#3413-data-bias-approval).
 
 ### 3.4.12 Use representative data
 **Model developer or data engineer**: Use identified available representative data.
@@ -280,14 +280,14 @@ Move to [step 3.4.13](#3.4.13-Data-bias-approval).
 
 If applicable, add any additional details:
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
 
 ### 3.4.13 Data bias approval
 **Model owner**: Do you approve the assessment and documentation of bias risks?
@@ -297,11 +297,11 @@ If applicable, add any additional details:
 
 If no, please justify your response and reassign step 3 for completion.
 
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ## 3.5 Approve data
 **Model owner**: Is the quality of the data acceptable? Has the data been appropriately cleaned? Does a review suggest data should be approved for use?
@@ -311,10 +311,8 @@ If no, please justify your response and reassign step 3 for completion.
 
 If no, please justify your response and reassign step 3 for completion.
 
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
-
-
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>

--- a/website/docs/4-train-model.md
+++ b/website/docs/4-train-model.md
@@ -6,27 +6,27 @@ sidebar_position: 5
 Train and assess a set of models to help find the best model for production.
 ## 4.1 Train models
 **Model developer**: Train and fine-tune several models. Document a set of promising models. Note the location of the models and modeling assets:
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+<br></br>
 
 ## 4.2 Document model evaluation metrics
 **Model developer**: Document all fit statistics used for model evaluation. Note resulting values for promising models.
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-</br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+<br></br>
 
 ## 4.3 Assess model bias
 
@@ -34,46 +34,47 @@ Train and assess a set of models to help find the best model for production.
 **Model developer**: Does the model require bias evaluation, based on the implications for the use of the AI system, among other factors?
 
 * [ ] Yes. If selected, continue to the next step.
-* [ ] No. If selected, move to step [4.3.4](#4.3.4-Bias-metrics-differences-approval).
+* [ ] No. If selected, move to step [4.3.4](#434-bias-metrics-differences-approval).
 
 If applicable, add any additional details:
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 4.3.2 Compare and document subgroup model performance
 **Model developer**: Calculate and compare model performance values and additional fairness metrics for each protected class or subgroup.
-To calculate model performance values, use model performance metrics defined by your organization in the testing strategy outlined in [step 2.1.6]((2-document-project.md). Fairness metrics might include equal opportunity, demographic parity, predictive parity, equal accuracy, or equalized odds. Subgroups are often protected classes. However, they could be important groups within the data based on the model use case, even though they are not legally defined as protected classes.
+To calculate model performance values, use model performance metrics defined by your organization in the testing strategy outlined in [step 2.1.6](2-document-project.md). Fairness metrics might include equal opportunity, demographic parity, predictive parity, equal accuracy, or equalized odds. Subgroups are often protected classes. However, they could be important groups within the data based on the model use case, even though they are not legally defined as protected classes.
 
 Document or save results. 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 4.3.3 Compare abd document average model predictions per subgroup
 **Model developer**: Calculate and compare average model predictions for each protected class or subgroup.
 Protected classes are groups of people who are legally protected from discrimination based on a shared characteristic, like disability, sexual orientation, or race.
-Subgroups are often protected classes. However, they could be important groups within the data based on the model use case, even though they are not legally defined as protected classes.
+Subgroups are often protected classes.
+However, they could be important groups within the data based on the model use case, even though they are not legally defined as protected classes.
 
 Document or save results. 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 4.3.4 Bias metrics differences approval
 **Model owner**: Is the documentation provided by the model developer satisfactor? If bias evaluation is required, are the differences in bias metric values satisfactory?
@@ -90,14 +91,14 @@ If no, which areas need additional review?
 * [ ]  End the workflow. If selected, please depreciate the project and update [step 2.1.1](2-document-project.md). 
 * [ ]  Move forward with the model. If selected, please continue to the next step and provide additional details or justification below.
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ## 4.4 Assess model explainability
 
@@ -108,17 +109,17 @@ An explainable model allows human users to comprehend and trust the results of t
 Is explainability important for this use case?
 
 * [ ] Yes. If selected, continue to the next step. 
-* [ ] No. If selected, move to step [4.4.3](#4.4.3-Model-explanations-approval). 
+* [ ] No. If selected, move to step [4.4.3](#443-model-explanations-approval). 
 
 If applicable, add any additional details:
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 4.4.2 Document model explainability
 **Model developer**: Document model explainability method and results.
@@ -126,14 +127,14 @@ Ensure that explainability information is made available to the model end user.S
 SAS Viya includes explainability tools such as Partial Dependence (PD) plots, Individual Conditional Expectation (ICE) plots, Local Interpretable Model-Agnostic Explanation (LIME), and Kernel Shapley values (Kernel SHAP). These techniques are model-agnostic, which means that these techniques can be applied to any model that is generated by a supervised learning node.
 
 Document or save results. 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 4.4.3 Model explanations approval
 **Model owner**: Is the documentation provided by the model developer satisfactor? If explanability is required, are the models' level of explainability acceptable?
@@ -149,11 +150,11 @@ If no, which areas need additional review?
 * [ ]  Update the project documentation, if selected, please return to [step 2](2-document-project.md). 
 * [ ]  End the workflow. If selected, please depreciate the project and update [step 2.1.1](2-document-project.md). 
 * [ ]  Move forward with the model. If selected, please continue to the next step and provide additional details or justification below.
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>

--- a/website/docs/5-test-model.md
+++ b/website/docs/5-test-model.md
@@ -10,18 +10,18 @@ Robust model testing can find issues before a model is deployed to production.
 ### 5.1.1 Select champion model
 **Model developer**: Based on performance during training, select the best candidate for production as the champion model. 
 
-> </br> 
-> </br> 
+> <br></br> 
+> <br></br> 
 
 ### 5.1.2 Select challenger model(s)
 
 **Model developer**: Based on performance during training, note promising challenger models. 
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br>
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br>
 
 ## 5.2 Test model
 
@@ -33,14 +33,14 @@ Robust model testing can find issues before a model is deployed to production.
 
 If applicable, add any additional details:
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
 
 ### 5.2.2 Run tests
 **Model developer**: Once the data engineer has prepared the test data, test the model according to the testing strategy defined in step [step 2.5.2](2-document-project.md). 
@@ -50,14 +50,14 @@ If applicable, add any additional details:
 
 If applicable, add any additional details:
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
 
 ### 5.2.3 Document test steps
 **Model developer**: Document the steps that you took to test the model and note results.
@@ -65,14 +65,14 @@ If applicable, add any additional details:
 * [ ] Completed
 * [ ] Not Completed
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
 
 ### 5.2.4 Tests passed?
 **Model developer**: Did the model pass the tests outlined in the testing strategy?
@@ -89,15 +89,15 @@ If no, which areas need additional review?
 * [ ]  End the workflow. If selected, please depreciate the project and update [step 2.1.1](2-document-project.md).
 * [ ]  Move forward with the model. If selected, please continue and provide additional details or justification below. 
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br>
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br>
 
 ## 5.3 Model approved for production?
 **Model owner**: Is the model approved for production?
@@ -114,11 +114,11 @@ If no, which areas need additional review?
 * [ ]  End the workflow. If selected, please depreciate the project and update [step 2.1.1](2-document-project.md). 
 * [ ]  Move forward with the model. If selected, please continue to the next step and provide additional details or justification below. 
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 

--- a/website/docs/6-deploy-model.md
+++ b/website/docs/6-deploy-model.md
@@ -16,14 +16,14 @@ Deploying models allows them to be incorporated within an organization's technic
 
 If applicable, add any additional details:
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
 
 ### 6.1.2  Deployment validation test passed?
 
@@ -34,14 +34,14 @@ Did the model deploymnet pass the deployment validation test?
 * [ ] No
 
 If applicable, add any additional details and reassign to resolve issues:
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 6.1.3 Incorporate model into existing processes
 
@@ -51,11 +51,11 @@ If applicable, add any additional details and reassign to resolve issues:
 
 If applicable, add any additional details:
 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
-> </br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 
+> <br></br> 

--- a/website/docs/7-monitor-model.md
+++ b/website/docs/7-monitor-model.md
@@ -10,26 +10,26 @@ Models become less effective over time, so it is important to monitor models for
 ### 7.1.1 Create model monitoring plan
 **Model developer or model engineer**: Create a model monitoring plan. Document the Key Performance Indicators (KPIs) that you will monitor, their thresholds, and the frequency at which they will be monitored: 
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 7.1.2 Execute and schedule model monitoring and KPIs
 **Model developer or model engineer**: Execute and schedule your model monitoring plan. Document or save the model's performance for the chosen KPIs. Repeat at each candense: 
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
 
 ### 7.1.3 Review project KPI thresholds
 **Model owner**: Review the project's KPI thresholds at the cadence that was deemed appropriate by your organization.
@@ -42,13 +42,13 @@ The model no longer meets predetermined thresholds. What are the next steps?
 * [ ] Set a new champion model. If selected, please return to [step 5](5-test-model.md). 
 * [ ] Update the project documentation, if selected, please return to [step 2](2-document-project.md). 
 * [ ] End the workflow. If selected, please depreciate the project and update [step 2.1.1](2-document-project.md). 
-* [ ] Move forward with the model. If selected, please continue with [step 7.1.2](#7.1.2-Execute-and-schedule-model-monitoring-and-KPIs).
+* [ ] Move forward with the model. If selected, please continue with [step 7.1.2](#712-execute-and-schedule-model-monitoring-and-KPIs).
 
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>

--- a/website/docs/8-review-project.md
+++ b/website/docs/8-review-project.md
@@ -20,14 +20,14 @@ Do any areas need additional attention?
 * [ ] Modify or update data. If selected, please return to [step 3](3-prepare-and-assess-data.md). 
 * [ ] Re-evaluate models. If selected, please return to [step 5](5-test-model.md).
 * [ ] End the workflow. If selected, please depreciate the project and update [step 2.1.1](2-document-project.md). 
-* [ ] Move forward with the model. If selected, please continue with step [8.1.1](#8.1.1-Review-production-model).
+* [ ] Move forward with the model. If selected, please continue with step [8.1.1](#811-review-production-model).
 
 If applicable, add any additional details:
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
-> </br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>
+> <br></br>

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -12,4 +12,4 @@ As a result, teams can produce documentation to support the assertion that the o
 The SAS Trustworthy AI Life Cycle is a stepwise process organized into sections.
 Many tasks in the life cycle reflect guidelines put forth by the [NIST AI Risk Management Framework Playbook](https://www.nist.gov/itl/ai-risk-management-framework) as it appeared in October 2023.
 
-For complete details, see the main project [README](../../README.md).
+For complete details, see the main project README.


### PR DESCRIPTION
This pull request suggests certain changes to appease the Docusaurus documentation engine. Testing reveals that:

* **The engine expects HTML tag pairs**, so standalone `</br>` tags were breaking builds. These have now been changed to the following syntax: `<br></br>`
* **Relative hyperlinks cannot contain dots or capital letters**, so all URLs have been edited to remove and alter these